### PR TITLE
Add override axis for Toshiba Satellite R830

### DIFF
--- a/hwdb/60-evdev.hwdb
+++ b/hwdb/60-evdev.hwdb
@@ -461,6 +461,13 @@ evdev:name:AlpsPS/2 ALPS DualPoint TouchPad:dmi:*svnTOSHIBA:pnTECRAM11*
  EVDEV_ABS_00=90:962:11
  EVDEV_ABS_01=51:681:14
 
+# Toshiba Satellite R830
+evdev:name:SynPS/2 Synaptics TouchPad:dmi:*svnTOSHIBA:pnSATELLITER830*
+ EVDEV_ABS_00=1238:5785:53
+ EVDEV_ABS_01=1045:4826:76
+ EVDEV_ABS_35=1238:5785:53
+ EVDEV_ABS_36=1045:4826:76
+ 
 #########################################
 # Razer
 #########################################


### PR DESCRIPTION
Incorrect range and resolution for the touchpad at a Toshiba Satellite R830 reported by kernel. After running 

$ sudo touchpad-edge-detector 85x50 /dev/input/event4

the new axis overrides are as follows

# Toshiba Satellite R830
evdev:name:SynPS/2 Synaptics TouchPad:dmi:*svnTOSHIBA:pnSATELLITER830*
 EVDEV_ABS_00=1238:5785:53
 EVDEV_ABS_01=1045:4826:76
 EVDEV_ABS_35=1238:5785:53
 EVDEV_ABS_36=1045:4826:76

Those overrides have been tested to work. Maybe they could go into hwdb.d/60-evdev.hwdb